### PR TITLE
Pass-through URLs should not have a . appended between the host and t…

### DIFF
--- a/Succulent/Classes/Succulent.swift
+++ b/Succulent/Classes/Succulent.swift
@@ -119,7 +119,7 @@ public class Succulent : NSObject, URLSessionTaskDelegate {
                 res.data = trace.responseBody
                 resultBlock(.response(res))
             } else if let baseUrl = self.baseUrl {
-                let url = URL(string: ".\(req.file)", relativeTo: baseUrl)!
+                let url = URL(string: "\(req.file)", relativeTo: baseUrl)!
                 
                 print("Pass-through URL: \(url.absoluteURL)")
                 var urlRequest = URLRequest(url: url)


### PR DESCRIPTION
Pass through URLs are appending a "." between the hostname and the appended path.

Current:
http://example.com/.api/v1/user

Proposed:
http://example.com/api/v1/user