### PR TITLE
Revert "Pass-through URLs should not have a . appended between the host and t…"

### DIFF
--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -200,6 +200,14 @@ class Tests: XCTestCase, SucculentTest {
         }
     }
     
+    func testPassThroughURLPreservation() {
+        suc.baseUrl = URL(string: "http://www.cactuslab.com/api/")
+        
+        GET("index.html") { (data, response, error) in
+            XCTAssertTrue(response?.url?.absoluteString == "http://cactuslab.com/api/index.html", "The responseURL was \(response?.url?.absoluteString ?? "nil")")
+        }
+    }
+    
     func testHeaders() {
         GET("headers/index.html") { (data, response, error) in
             XCTAssertEqual(response?.statusCode, 404)

--- a/Succulent/Classes/Succulent.swift
+++ b/Succulent/Classes/Succulent.swift
@@ -119,6 +119,7 @@ public class Succulent : NSObject, URLSessionTaskDelegate {
                 res.data = trace.responseBody
                 resultBlock(.response(res))
             } else if let baseUrl = self.baseUrl {
+                // Using a '.' prefix here preserves the path components of the baseUrl if there are any
                 let url = URL(string: ".\(req.file)", relativeTo: baseUrl)!
                 
                 print("Pass-through URL: \(url.absoluteURL)")

--- a/Succulent/Classes/Succulent.swift
+++ b/Succulent/Classes/Succulent.swift
@@ -119,7 +119,7 @@ public class Succulent : NSObject, URLSessionTaskDelegate {
                 res.data = trace.responseBody
                 resultBlock(.response(res))
             } else if let baseUrl = self.baseUrl {
-                let url = URL(string: "\(req.file)", relativeTo: baseUrl)!
+                let url = URL(string: ".\(req.file)", relativeTo: baseUrl)!
                 
                 print("Pass-through URL: \(url.absoluteURL)")
                 var urlRequest = URLRequest(url: url)


### PR DESCRIPTION
Reverts cactuslab/Succulent#2